### PR TITLE
Add MessageEditorTab and Scanner insertion points

### DIFF
--- a/burp_grpc_decodetab.py
+++ b/burp_grpc_decodetab.py
@@ -1,0 +1,112 @@
+from burp import IBurpExtender
+from burp import IContextMenuFactory, IContextMenuInvocation
+from java.io import PrintWriter
+from javax.swing import JMenuItem
+import subprocess
+from java.lang import System
+import os
+import commands
+from burp import IMessageEditorTabFactory
+from burp import IMessageEditorTab
+from burp import IScannerInsertionPointProvider
+from burp import IScannerInsertionPoint
+from burp import IIntruderPayloadProcessor
+from array import array
+import traceback
+
+import grpc_utils
+
+
+
+class ProtoDecodeTab(IMessageEditorTab):
+
+    def __init__(self, extender, controller, editable, helpers):
+        self._extender = extender
+        self._editable = editable
+
+        # create an instance of Burp's text editor, to display our deserialized data
+        self._txtInput = extender._callbacks.createTextEditor()
+        self._txtInput.setEditable(editable)
+        self._current_payload = ""
+
+        self.stdout = PrintWriter(extender._callbacks.getStdout(), True)
+        self.stderr = PrintWriter(extender._callbacks.getStderr(), True)
+
+    #
+    # implement IMessageEditorTab
+    #
+    def pprint(self, text):
+        self.stdout.println(text)
+
+    def getTabCaption(self):
+        return "Decoded Protobuf"
+
+    def getUiComponent(self):
+        return self._txtInput.getComponent()
+
+    def isEnabled(self, content, isRequest):
+        # enable this tab for requests containing a data parameter
+        return True
+
+    def setMessage(self, content, isRequest):
+        if (content is None):
+            # clear our display
+            self._txtInput.setText(None)
+            self._txtInput.setEditable(False)
+
+        else:
+            # retrieve the serialized data
+            requestInfo = self._extender.helpers.analyzeRequest(content)
+            headers = requestInfo.getHeaders()
+            msgBody = content[requestInfo.getBodyOffset():]
+
+            newHeaders = list(headers)
+
+            if not len(newHeaders) > 0:
+                print("No headers")
+                print(newHeaders)
+                return
+
+            query_line = newHeaders[0]
+
+            if " " not in query_line:
+                print("No space in query line? ")
+                print(query_line)
+                return
+
+            # build a new http message
+            method = query_line.split(" ")[0]
+
+            msgBody = self._extender.helpers.bytesToString(msgBody)
+            decodedData = grpc_utils.get_decoded_payload_grpc_web_text(msgBody)
+            self._current_payload = decodedData
+            # deserialize the parameter value
+            self._txtInput.setText(decodedData)
+            self._txtInput.setEditable(self._editable)
+
+        # remember the displayed content
+        self._currentMessage = content
+        return
+
+    def getMessage(self):
+        # determine whether the user modified the deserialized data
+        if (self._txtInput.isTextModified()):
+            payload = self._txtInput.getText()
+            payload = self._extender.helpers.bytesToString(payload)
+            encoded_data = grpc_utils.get_encoded_payload_grpc_web_text(str(payload))
+            requestInfo = self._extender.helpers.analyzeRequest(self._currentMessage)
+            content = self._currentMessage[:requestInfo.getBodyOffset()]
+
+            new_request_bytes = self._extender.helpers.stringToBytes(encoded_data)
+            content = content + new_request_bytes
+            return content
+        else:
+            return self._currentMessage
+
+    def isModified(self):
+
+        return self._txtInput.isTextModified()
+
+    def getSelectedData(self):
+
+        return self._txtInput.getSelectedText()

--- a/burp_grpc_extension_main.py
+++ b/burp_grpc_extension_main.py
@@ -1,0 +1,523 @@
+from burp import IBurpExtender
+from burp import IContextMenuFactory, IContextMenuInvocation
+from java.io import PrintWriter
+from javax.swing import JMenuItem
+import subprocess
+from java.lang import System
+import os
+import commands
+from burp import IMessageEditorTabFactory
+from burp import IMessageEditorTab
+from burp import IScannerInsertionPointProvider
+from burp import IScannerInsertionPoint
+from burp import IIntruderPayloadProcessor
+from array import array
+import traceback
+
+import grpc_utils
+from burp_grpc_decodetab import ProtoDecodeTab
+from burp_grpc_insertionpoint import GrpcInsertionPoint
+
+
+class BurpExtender(IBurpExtender, IContextMenuFactory, IMessageEditorTabFactory, IScannerInsertionPointProvider, IIntruderPayloadProcessor):
+
+    def registerExtenderCallbacks(self, callbacks):
+        self.helpers = callbacks.getHelpers()
+        callbacks.setExtensionName('gRPC-Web Coder')
+        callbacks.registerContextMenuFactory(self)
+        self.stdout = PrintWriter(callbacks.getStdout(), True)
+        self.stderr = PrintWriter(callbacks.getStderr(), True)
+        callbacks.registerMessageEditorTabFactory(self)
+        callbacks.registerScannerInsertionPointProvider(self)
+        callbacks.registerIntruderPayloadProcessor(self)
+        self._callbacks = callbacks
+
+    def getInsertionPoints(self, baseRequestResponse):
+        request = baseRequestResponse.getRequest()
+        requestInfo = self.helpers.analyzeRequest(request)
+
+        # check if gRPC request
+        headers = requestInfo.getHeaders()
+        isGrpc = False
+        for header in headers:
+            if header.lower().startswith("content-type: application/grpc"):
+                isGrpc = True
+                break
+
+        if not isGrpc:
+            return None
+
+        body = request[requestInfo.getBodyOffset():]
+        decoded = self.decode_grpc_payload(body)
+
+        try:
+            # Use the new find_insertion_points function
+            found_points = grpc_utils.find_insertion_points(decoded)
+
+            # Convert the found points into Burp insertion points
+            insertionPoints = []
+            for point in found_points:
+                insertionPoints.append(
+                    GrpcInsertionPoint(
+                        self,
+                        request,
+                        requestInfo.getBodyOffset(),
+                        decoded,
+                        point['name'],  # Using the name from the found point
+                        field_path=point['path']  # Using the path from the found point
+                    )
+                )
+
+            return insertionPoints
+
+        except:
+            print("Error creating insertion points")
+            print(traceback.format_exc())
+            return None
+
+    def getProcessorName(self):
+        return "gRPC Payload Processor"
+
+    def processPayload(self, currentPayload, originalPayload, baseValue):
+        """Implement IIntruderPayloadProcessor"""
+        # Encode the payload for gRPC
+        try:
+            payload = self.helpers.bytesToString(currentPayload)
+            encoded = grpc_utils.get_encoded_payload_grpc_web_text(payload)
+            return self.helpers.stringToBytes(encoded)
+        except:
+            return currentPayload
+
+    def decode_grpc_payload(self, payload):
+        """decode gRPC payload"""
+        try:
+            payload_str = self.helpers.bytesToString(payload)
+            return grpc_utils.get_decoded_payload_grpc_web_text(payload_str)
+        except:
+            print("Error decoding gRPC payload")
+            print(traceback.format_exc())
+            print(str(payload))
+            return payload
+
+    def createNewInstance(self, controller, editable):
+        
+        return ProtoDecodeTab(self, controller, editable, self.helpers)
+
+    def createMenuItems(self, invocation):
+
+        context = invocation.getInvocationContext()
+
+        selected_payload = self.get_selected_text(invocation)
+        payload_index = self.get_index_of_selected_text(invocation)
+        if context == IContextMenuInvocation.CONTEXT_MESSAGE_EDITOR_REQUEST \
+                or context == IContextMenuInvocation.CONTEXT_MESSAGE_VIEWER_REQUEST \
+                and selected_payload is not None:
+
+            label_encode_grpc_web_text = 'Encode application/grpc-web-text'
+            label_decode_grpc_web_text = 'Decode application/grpc-web-text'
+
+            menu_item_encoding_grpc_web_text = JMenuItem(label_encode_grpc_web_text, actionPerformed=self.encode_payload_grpc_web_text)
+            menu_item_encoding_grpc_web_text.putClientProperty('grpc_selected_payload', selected_payload)
+            menu_item_encoding_grpc_web_text.putClientProperty('grpc_selected_payload_index', payload_index)
+            menu_item_encoding_grpc_web_text.putClientProperty('grpc_encoding_invocation', invocation)
+
+            menu_item_decoding_grpc_web_text = JMenuItem(label_decode_grpc_web_text, actionPerformed=self.decode_payload_grpc_web_text)
+            menu_item_decoding_grpc_web_text.putClientProperty('grpc_selected_payload', selected_payload)
+            menu_item_decoding_grpc_web_text.putClientProperty('grpc_selected_payload_index', payload_index)
+            menu_item_decoding_grpc_web_text.putClientProperty('grpc_decoding_invocation', invocation)
+
+            # label_encode_grpc_web = 'Encode application/grpc-web+proto'
+            # label_decode_grpc_web = 'Decode application/grpc-web+proto'
+            #
+            # menu_item_encoding_grpc_web = JMenuItem(label_encode_grpc_web, actionPerformed=self.encode_payload_grpc_web)
+            # menu_item_encoding_grpc_web.putClientProperty('grpc_selected_payload', selected_payload)
+            # menu_item_encoding_grpc_web.putClientProperty('grpc_selected_payload_index', payload_index)
+            # menu_item_encoding_grpc_web.putClientProperty('grpc_encoding_invocation', invocation)
+            #
+            # menu_item_decoding_grpc_web = JMenuItem(label_decode_grpc_web, actionPerformed=self.decode_payload_grpc_web)
+            # menu_item_decoding_grpc_web.putClientProperty('grpc_selected_payload', selected_payload)
+            # menu_item_decoding_grpc_web.putClientProperty('grpc_selected_payload_index', payload_index)
+            # menu_item_decoding_grpc_web.putClientProperty('grpc_decoding_invocation', invocation)
+
+            label_big_string_chunker = 'Chunk Big String'
+            menu_item_big_string_chunker = JMenuItem(label_big_string_chunker, actionPerformed=self.chunk_big_string)
+            menu_item_big_string_chunker.putClientProperty('big_string_selected_payload', selected_payload)
+            menu_item_big_string_chunker.putClientProperty('big_string_selected_payload_index', payload_index)
+            menu_item_big_string_chunker.putClientProperty('big_string_invocation', invocation)
+
+            label_un_chunk_chunked_string = 'Un-Chunk Chunked String'
+            menu_item_un_chunk_chunked_string = JMenuItem(
+                label_un_chunk_chunked_string,
+                actionPerformed=self.un_chunk_chunked_string
+            )
+            menu_item_un_chunk_chunked_string.putClientProperty('chunked_string_selected_payload', selected_payload)
+            menu_item_un_chunk_chunked_string.putClientProperty('chunked_string_selected_payload_index', payload_index)
+            menu_item_un_chunk_chunked_string.putClientProperty('chunked_string_invocation', invocation)
+
+            return [
+                menu_item_decoding_grpc_web_text,
+                menu_item_encoding_grpc_web_text,
+                # menu_item_decoding_grpc_web,
+                # menu_item_encoding_grpc_web,
+                menu_item_big_string_chunker,
+                menu_item_un_chunk_chunked_string,
+            ]
+
+    def un_chunk_chunked_string(self, event):
+        """
+        Un-Chunk chunked string (remove ['"','\n','  '])
+        :param event:
+        :return:
+        """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('chunked_string_selected_payload')
+        _invocation = menu_item.getClientProperty('chunked_string_invocation')
+        _index = menu_item.getClientProperty('chunked_string_selected_payload_index')
+
+        temp_file_path = 'chunked_string.txt'
+
+        with open(temp_file_path, "w") as file:
+            file.write(selected_payload.strip())
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = python_name + " big-string-chunker.py --file chunked_string.txt --un-chunk"
+
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        # output = output.decode('utf-8')
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_decoded_request_grpc_web_text(_invocation, _index, output)
+
+        return None
+
+    def chunk_big_string(self, event):
+        """
+        Chunk big string into pieces of 80 characters using big-string-chunker.py
+        :param event:
+        :return:
+        """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('big_string_selected_payload')
+        _invocation = menu_item.getClientProperty('big_string_invocation')
+        _index = menu_item.getClientProperty('big_string_selected_payload_index')
+
+        temp_file_path = 'big_string.txt'
+
+        with open(temp_file_path, "w") as file:
+            file.write(selected_payload.strip())
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = python_name + " big-string-chunker.py --file big_string.txt --chunk"
+
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        # output = output.decode('utf-8')
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_decoded_request_grpc_web_text(_invocation, _index, output)
+
+        return None
+
+    def get_selected_text(self, invocation):
+        request_text = invocation.getSelectedMessages()[0].getRequest().tostring().decode('utf-8')
+
+        text_index = invocation.getSelectionBounds()
+        start_index = text_index[0]
+        end_index = text_index[1]
+
+        selected_text = request_text[start_index:end_index]
+
+        return selected_text
+
+    def get_index_of_selected_text(self, invocation):
+
+        text_index = invocation.getSelectionBounds()
+        start_index = text_index[0]
+        end_index = text_index[1]
+
+        return (start_index, end_index)
+
+    def update_decoded_request_grpc_web_text(self, invocation, index, new_payload):
+        """
+        update the request with decoded value
+        application/grpc-web-text Content-Type
+        :param invocation:
+        :param index:
+        :param new_payload:
+        :return:
+        """
+        # index is a tuple --> (start_index, end_index)
+
+        old_request_string = invocation.getSelectedMessages()[0].getRequest().tostring()
+
+        new_request_string = old_request_string[:index[0]] + new_payload + old_request_string[index[1] + 1:]
+        new_request_bytes = self.helpers.stringToBytes(new_request_string)
+        invocation.getSelectedMessages()[0].setRequest(new_request_bytes)
+
+    def update_decoded_request_grpc_web(self, invocation, index, new_payload):
+        """
+        update the request with decoded value
+        application/grpc-web+proto Content-Type
+        :param invocation:
+        :param index:
+        :param new_payload:
+        :return:
+        """
+        # index is a tuple --> (start_index, end_index)
+
+        old_request_string = invocation.getSelectedMessages()[0].getRequest().tostring()
+
+        new_request_string = old_request_string[:index[0]] + new_payload + old_request_string[index[1] + 1:]
+        new_request_bytes = self.helpers.stringToBytes(new_request_string)
+        invocation.getSelectedMessages()[0].setRequest(new_request_bytes)
+
+    def update_encoded_request_grpc_web_text(self, invocation, index, new_payload):
+        """
+        update the request with encoded value
+        application/grpc-web-text Content-Type
+        :param invocation:
+        :param index:
+        :param new_payload:
+        :return:
+        """
+        # index is a tuple --> (start_index, end_index)
+
+        old_request_string = invocation.getSelectedMessages()[0].getRequest().tostring().decode('utf-8')
+
+        new_request_string = old_request_string[:index[0]] + new_payload + old_request_string[index[1] + 1:]
+        new_request_bytes = self.helpers.stringToBytes(new_request_string)
+        invocation.getSelectedMessages()[0].setRequest(new_request_bytes)
+
+    def update_encoded_request_grpc_web(self, invocation, index, new_payload):
+        """
+        update the request with encoded value
+        application/grpc-web+proto Content-Type
+        :param invocation:
+        :param index:
+        :param new_payload:
+        :return:
+        """
+        # index is a tuple --> (start_index, end_index)
+
+        old_request_string = invocation.getSelectedMessages()[0].getRequest().tostring().decode('utf-8')
+
+        new_request_string = old_request_string[:index[0]] + new_payload + old_request_string[index[1] + 1:]
+        new_request_bytes = self.helpers.stringToBytes(new_request_string)
+        invocation.getSelectedMessages()[0].setRequest(new_request_bytes)
+
+    def encode_payload_grpc_web_text(self, event):
+        """
+        Encode application/grpc-web-text Content-Type
+        :param event:
+        :return:
+        """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('grpc_selected_payload')
+        _invocation = menu_item.getClientProperty('grpc_encoding_invocation')
+        _index = menu_item.getClientProperty('grpc_selected_payload_index')
+
+        temp_file_path_encoding = 'grpc_coder_output_encode.txt'
+
+        try:
+            with open(temp_file_path_encoding, "w") as temp_encoding_file:
+                temp_encoding_file.write(selected_payload.strip().encode('utf-8'))
+        except Exception as e:
+            self.pprint(str(e))
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = grpc_utils.PROTOSCOPE_PATH + " -s grpc_coder_output_encode.txt | " + python_name + " grpc-coder.py --encode"
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        output = output.decode('utf-8')
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path_encoding):
+            try:
+                os.remove(temp_file_path_encoding)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_encoded_request_grpc_web_text(_invocation, _index, output)
+
+        return None
+
+    def decode_payload_grpc_web_text(self, event):
+        """
+        Decode application/grpc-web-text Content-Type
+        :param event:
+        :return:
+        """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('grpc_selected_payload')
+        _invocation = menu_item.getClientProperty('grpc_decoding_invocation')
+        _index = menu_item.getClientProperty('grpc_selected_payload_index')
+
+        temp_file_path = 'grpc_coder_output_decode.txt'
+
+        with open(temp_file_path, "w") as file:
+            file.write(selected_payload.strip())
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = python_name + " grpc-coder.py --decode --file grpc_coder_output_decode.txt | " + grpc_utils.PROTOSCOPE_PATH
+
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        # output = output.decode('utf-8')
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_decoded_request_grpc_web_text(_invocation, _index, output)
+
+        return None
+
+    def encode_payload_grpc_web(self, event):
+        """
+       Encode application/grpc-web+proto Content-Type
+       :param event:
+       :return:
+       """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('grpc_selected_payload')
+        _invocation = menu_item.getClientProperty('grpc_encoding_invocation')
+        _index = menu_item.getClientProperty('grpc_selected_payload_index')
+
+        temp_file_path_encoding = 'grpc_coder_output_encode.txt'
+
+        try:
+            with open(temp_file_path_encoding, "w") as temp_encoding_file:
+                temp_encoding_file.write(selected_payload.strip())
+        except Exception as e:
+            self.pprint(str(e))
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = grpc_utils.PROTOSCOPE_PATH + " -s grpc_coder_output_encode.txt | " + python_name + " grpc-coder.py --encode --type grpc-web+proto"
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path_encoding):
+            try:
+                os.remove(temp_file_path_encoding)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_encoded_request_grpc_web(_invocation, _index, output)
+
+        return None
+
+    def decode_payload_grpc_web(self, event):
+        """
+        Decode application/grpc-web+proto Content-Type
+        :param event:
+        :return:
+        """
+
+        menu_item = event.getSource()
+        selected_payload = menu_item.getClientProperty('grpc_selected_payload')
+        _invocation = menu_item.getClientProperty('grpc_decoding_invocation')
+        _index = menu_item.getClientProperty('grpc_selected_payload_index')
+
+        temp_file_path = 'grpc_coder_output_decode.txt'
+
+        with open(temp_file_path, "wb") as file:
+            file.write(selected_payload.strip())
+
+        python_name = "python"
+        if not System.getProperty('os.name').startswith("Windows"):
+            status, _ = commands.getstatusoutput('which python3')
+            if status != 0:
+                python_name = "python"
+            else:
+                python_name = "python3"
+
+        command = python_name + " grpc-coder.py --decode --file grpc_coder_output_decode.txt --type grpc-web+proto | " + grpc_utils.PROTOSCOPE_PATH
+
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        # output = output.decode('utf-8')
+        output = output.strip()
+
+        # Check if the file exists before attempting to remove it
+        if os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except OSError as e:
+                self.pprint(str(e))
+
+        if output:
+            self.update_decoded_request_grpc_web(_invocation, _index, output)
+
+        return None
+
+    def pprint(self, text):
+        self.stdout.println(text)
+
+    def print_error(self, text):
+        """
+        write error
+        :return:
+        """
+        self.stderr.println(str(text))
+

--- a/burp_grpc_insertionpoint.py
+++ b/burp_grpc_insertionpoint.py
@@ -1,0 +1,104 @@
+from burp import IBurpExtender
+from burp import IContextMenuFactory, IContextMenuInvocation
+from java.io import PrintWriter
+from javax.swing import JMenuItem
+import subprocess
+from java.lang import System
+import os
+import commands
+from burp import IMessageEditorTabFactory
+from burp import IMessageEditorTab
+from burp import IScannerInsertionPointProvider
+from burp import IScannerInsertionPoint
+from burp import IIntruderPayloadProcessor
+from array import array
+import traceback
+
+import grpc_utils
+
+
+class GrpcInsertionPoint(IScannerInsertionPoint):
+    INS_EXTENSION_PROVIDED = 65
+
+    def __init__(self, extender, baseRequest, offset, decodedData, insertionPointName, field_path=None):
+        self._extender = extender
+        self._baseRequest = baseRequest
+        self._offset = offset
+        self._originalData = decodedData
+        self._insertionPointName = insertionPointName
+        self._field_path = field_path or []  # Track the path to this field in nested structure
+        self._fullMessage = decodedData
+
+        try:
+            print("\nParsing:", decodedData)
+            self._baseValue = grpc_utils.extract_value_from_path(self._field_path, decodedData)
+
+        except:
+            print("Error parsing gRPC structure in insertion point")
+            print(traceback.format_exc())
+
+    def buildRequest(self, payload):
+        try:
+            if isinstance(payload, array):
+                payload = "".join(map(chr, payload))
+            elif isinstance(payload, bytes):
+                payload = self._extender.helpers.bytesToString(payload)
+
+            print("Building request with payload:", payload)
+            print("Current field path:", self._field_path)
+
+            new_message = grpc_utils.replace_value_at_path(self._fullMessage, self._field_path, payload)
+            print("Modified message:", new_message)
+
+            encodedPayload = grpc_utils.get_encoded_payload_grpc_web_text(new_message)
+            print("Decoded: ", grpc_utils.get_decoded_payload_grpc_web_text(encodedPayload))
+            # Validate encoded payload
+            if not encodedPayload:
+                print("Warning: Empty encoded payload")
+                return self._baseRequest
+
+            # Construct the new request
+            prefix = self._baseRequest[:self._offset]
+            encoded_bytes = self._extender.helpers.stringToBytes(encodedPayload)
+
+            # Build the complete request
+            result = prefix + encoded_bytes
+
+            # Add any remaining data after the body if needed
+            if self._offset + len(encoded_bytes) < len(self._baseRequest):
+                suffix = self._baseRequest[self._offset + len(encoded_bytes):]
+                result += suffix
+
+            print("Final request length:", len(result))
+            return result
+
+        except Exception as e:
+            print("Error building request:", str(e))
+            print(traceback.format_exc())
+            return self._baseRequest
+
+    def getPayloadOffsets(self, payload):
+        print("getPayloadOffsets called with payload:", payload)
+        try:
+            encoded_base = grpc_utils.get_encoded_payload_grpc_web_text(self._fullMessage)
+            base_bytes = self._extender.helpers.stringToBytes(encoded_base)
+            start = self._offset
+            end = start + len(base_bytes)
+            print("Calculated offsets:", [start, end])
+            return [start, end]
+        except:
+            print("Error calculating offsets")
+            print(traceback.format_exc())
+            return [self._offset, self._offset + len(payload)]
+
+    def getInsertionPointType(self):
+        print("getInsertionPointType called, returning:", self.INS_EXTENSION_PROVIDED)
+        return INS_EXTENSION_PROVIDED
+
+    def getInsertionPointName(self):
+        print("getInsertionPointName called, returning:", self._insertionPointName)
+        return self._insertionPointName
+
+    def getBaseValue(self):
+        print("getBaseValue called with base value:", self._baseValue)
+        return self._baseValue if self._baseValue is not None else ""

--- a/grpc_utils.py
+++ b/grpc_utils.py
@@ -1,0 +1,225 @@
+# grpc_utils.py
+import io
+import subprocess
+import os
+
+import traceback
+# Add at the top of the file:
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+PROTOSCOPE_PATH = "protoscope"
+
+
+def extract_value_from_path(field_path, message):
+    """Extract the value at the specified field path"""
+    if not field_path:
+        return message
+
+    lines = message.split('\n')
+    path_stack = []
+
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        while path_stack and indent <= path_stack[-1][0]:
+            path_stack.pop()
+
+        if ': {' in stripped:
+            field_num = stripped.split(':', 1)[0].strip()
+            value = stripped.split('{', 1)[1].rstrip('}').strip()
+
+            path_stack.append((indent, field_num))
+            current_path = [p[1] for p in path_stack]
+
+            if current_path == field_path:
+                if value.startswith('"') and value.endswith('"'):
+                    return value[1:-1]
+                return value
+
+    return None
+
+
+
+def replace_value_at_path(message, field_path, new_value):
+    """Replace value at the specified field path (escaping included)"""
+
+    def escape_value(val):
+        val = str(val)
+        val = val.replace('\\', '\\\\').replace('"', '\\"')
+        val = val.replace('\n', '\\n').replace('\r', '\\r')
+        return '"{}"'.format(val)
+
+    if not field_path:
+        return message
+
+    lines = message.split('\n')
+    result = []
+    path_stack = []
+
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        while path_stack and indent <= path_stack[-1][0]:
+            path_stack.pop()
+
+        if ': {' in stripped:
+            field_num = stripped.split(':', 1)[0].strip()
+            path_stack.append((indent, field_num))
+
+            current_path = [p[1] for p in path_stack]
+            if current_path == field_path:
+                escaped = escape_value(new_value)
+                new_line = ' ' * indent + field_num + ': {' + escaped + '}'
+                result.append(new_line)
+                continue
+
+        result.append(line)
+
+    return '\n'.join(result)
+
+
+def find_insertion_points(decoded_message):
+    """Find all possible insertion points in a decoded protobuf message"""
+    insertion_points = []
+
+    def parse_message(message, current_path=[]):
+        """Recursively parse protobuf message to find all fields"""
+        lines = message.split('\n')
+        path_stack = []
+        current_indent = 0
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            indent = len(line) - len(stripped)
+
+            # Adjust path stack based on indentation
+            while path_stack and indent <= path_stack[-1][0]:
+                path_stack.pop()
+
+            if ': {' in stripped:
+                field_num = stripped.split(':', 1)[0].strip()
+                value = stripped.split('{', 1)[1].rstrip('}').strip()
+
+                path_stack.append((indent, field_num))
+                new_path = [p[1] for p in path_stack]
+
+                if value == '':
+                    continue
+                # Add the current field as an insertion point
+                insertion_points.append({
+                    'path': new_path,
+                    'name': "gRPC field {}".format('.'.join(new_path)),
+                    'value': value
+                })
+
+                # If the value contains nested structure, parse it
+                if value.count('{') > value.count('"'):
+                    parse_message(value, new_path)
+
+    parse_message(decoded_message)
+    return insertion_points
+
+
+
+
+def get_decoded_payload_grpc_web_text(payload):
+    temp_file_path = 'grpc_coder_output_decode.txt'
+    temp_proto_path = 'proto_output.txt'
+
+    try:
+        # If payload is bytes, keep it as-is for base64
+        if isinstance(payload, bytes):
+            raw_payload = payload
+        else:
+            # If string/unicode, encode to ascii, ignoring problematic chars
+            raw_payload = payload.encode('ascii', 'ignore')
+
+        # Write raw bytes
+        with open(temp_file_path, 'wb') as file:
+            file.write(raw_payload)
+
+        python_name = "python"
+        if not os.name.startswith("Windows"):
+            try:
+                status = subprocess.check_output('which python3', shell=True)
+                python_name = "python3"
+            except subprocess.CalledProcessError:
+                python_name = "python"
+
+        command = [python_name, "grpc-coder.py", "--decode", "--file", temp_file_path]
+        decoded = subprocess.check_output(command, shell=False)
+
+        with open(temp_proto_path, 'wb') as f:
+            f.write(decoded)
+
+        try:
+            protoscope_command = [PROTOSCOPE_PATH, temp_proto_path]
+            protoscope_output = subprocess.check_output(protoscope_command, shell=False)
+            return protoscope_output
+        except subprocess.CalledProcessError as e:
+            return decoded
+
+    except:
+        return payload
+    finally:
+        for temp_file in [temp_file_path, temp_proto_path]:
+            if os.path.exists(temp_file):
+                try:
+                    os.remove(temp_file)
+                except:
+                    pass
+
+def get_encoded_payload_grpc_web_text(payload):
+    temp_file_path_encoding = 'grpc_coder_output_encode.txt'
+    temp_proto_path = 'proto_output.txt'
+
+    try:
+        # If payload is bytes, keep it as-is for base64
+        if isinstance(payload, bytes):
+            raw_payload = payload
+        else:
+            # If string/unicode, encode to ascii, ignoring problematic chars
+            raw_payload = payload.encode('ascii', 'ignore')
+
+        # Write raw bytes
+        with open(temp_file_path_encoding, 'wb') as file:
+            file.write(raw_payload)
+
+        python_name = "python"
+        if not os.name.startswith("Windows"):
+            try:
+                status = subprocess.check_output('which python3', shell=True)
+                python_name = "python3"
+            except subprocess.CalledProcessError:
+                python_name = "python"
+
+        try:
+            protoscope_command = [PROTOSCOPE_PATH, "-s", temp_file_path_encoding]
+            with open(temp_proto_path, 'wb') as f:
+                subprocess.check_call(protoscope_command, stdout=f, shell=False)
+
+            encode_command = [python_name, "grpc-coder.py", "--encode", "--file", temp_proto_path]
+            output = subprocess.check_output(encode_command, shell=False)
+            return output.strip()
+
+        except subprocess.CalledProcessError:
+            encode_command = [python_name, "grpc-coder.py", "--encode", "--file", temp_file_path_encoding]
+            output = subprocess.check_output(encode_command, shell=False)
+            return output.strip()
+
+    except:
+        return payload
+    finally:
+        for temp_file in [temp_file_path_encoding, temp_proto_path]:
+            if os.path.exists(temp_file):
+                try:
+                    os.remove(temp_file)
+                except:
+                    pass

--- a/test_grpc_burp.py
+++ b/test_grpc_burp.py
@@ -1,0 +1,155 @@
+# test_grpc_fuzzing.py
+import pytest
+from grpc_utils import find_insertion_points, replace_value_at_path, extract_value_from_path
+from grpc_utils import get_encoded_payload_grpc_web_text, get_decoded_payload_grpc_web_text
+
+
+class TestGRPCFuzzing:
+    @pytest.fixture
+    def test_messages(self):
+        return {
+            'simple': '''1: {"test"}''',
+            'nested': '''1: {"' AND pg_sleep(20)--"}
+5: {"test"}
+10: {2: 15}''',
+            'multi_field': '''1: {
+  1: {"1234"}
+  3: {"test"}
+  5: {"test"}
+  10: {
+    1: {"test"}
+    2: {"test"}
+    5: {"18d157ca-72d3-4c26-999f-cf84d8135d8e"}
+    6: {"test"}
+  }
+}'''
+        }
+
+    @pytest.fixture
+    def test_payloads(self):
+        return [
+            '\'"><svg/onload=fetch`//test\\.oastify.com`>',
+            "' OR '1'='1",
+            '<script>alert(1)</script>',
+        ]
+
+    def validate_grpc_text(self, text):
+        """Check if the text follows gRPC-text format rules"""
+        if not text:
+            return False
+        text = text.decode('utf-8')
+        # Basic structure validation
+        lines = text.split('\n')
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Each line should either be a field definition or a nested structure
+            if ': {' in line:
+                field_num = line.split(':', 1)[0].strip()
+                if not field_num.isdigit():
+                    return False
+
+                value = line.split('{', 1)[1].rstrip('}').strip()
+                if value.startswith('"'):
+                    if not value.endswith('"'):
+                        return False
+                elif not value.replace('.', '').isdigit():
+                    return False
+
+        return True
+
+    def test_find_all_fuzzable_fields(self, test_messages):
+        """Test that we can locate all fuzzable fields in each message type"""
+        expected_fields = {
+            'simple': 1,  # Just field 1
+            'nested': 3,  # Fields 1, 5, and 10.2
+            'multi_field': 7  # All nested fields
+        }
+
+        for msg_type, message in test_messages.items():
+            points = find_insertion_points(message)
+            assert len(points) == expected_fields[msg_type], f"Wrong number of insertion points for {msg_type}"
+
+            # Verify each point has required properties
+            for point in points:
+                assert 'path' in point
+                assert 'name' in point
+                assert 'value' in point
+
+    def test_payload_injection_and_encoding(self, test_messages, test_payloads):
+        """Test injecting payloads into each field and validating the result"""
+        for msg_type, message in test_messages.items():
+            points = find_insertion_points(message)
+
+            for point in points:
+                for payload in test_payloads:
+                    # Inject payload
+                    modified = replace_value_at_path(message, point['path'], payload)
+
+                    if isinstance(modified, bytes):
+                        modified = modified.decode("utf-8")
+                    # Encode
+
+                    assert(type(modified) == str)
+                    encoded = get_encoded_payload_grpc_web_text(modified)
+                    assert encoded, f"Encoding failed for {msg_type} at {point['path']}"
+
+                    if isinstance(encoded, bytes):
+                        encoded = encoded.decode("utf-8")
+                    # Decode and validate
+                    decoded = get_decoded_payload_grpc_web_text(encoded)
+                    assert decoded, f"Decoding failed for {msg_type} at {point['path']}"
+
+                    print('-'*10)
+                    print(decoded.decode('utf-8'))
+
+
+
+
+    def test_encoding_roundtrip(self, test_messages, test_payloads):
+        """Test that messages remain valid after encode/decode roundtrip"""
+        for msg_type, message in test_messages.items():
+            # First roundtrip without modification
+            encoded = get_encoded_payload_grpc_web_text(message)
+            decoded = get_decoded_payload_grpc_web_text(encoded)
+
+            print('-' * 10)
+            print(decoded.decode('utf-8'))
+
+
+            # Then with modifications
+            points = find_insertion_points(message)
+            for point in points:
+                for payload in test_payloads:
+                    modified = replace_value_at_path(message, point['path'], payload)
+
+                    encoded = get_encoded_payload_grpc_web_text(modified)
+                    decoded = get_decoded_payload_grpc_web_text(encoded)
+
+                    print('-' * 10)
+                    print(decoded.decode('utf-8'))
+
+
+def test_field_value_preservation(self, test_messages):
+        """Test that non-modified fields retain their values"""
+        for msg_type, message in test_messages.items():
+            points = find_insertion_points(message)
+            original_values = {
+                tuple(point['path']): point['value']
+                for point in points
+            }
+
+            # Modify one field at a time
+            for point in points:
+                modified = replace_value_at_path(message, point['path'], "TEST_VALUE")
+                encoded = get_encoded_payload_grpc_web_text(modified)
+                decoded = get_decoded_payload_grpc_web_text(encoded)
+
+                # Check other fields remained unchanged
+                for other_point in points:
+                    if other_point['path'] != point['path']:
+                        value = extract_value_from_path(other_point['path'], decoded)
+                        assert value == original_values[tuple(other_point['path'])], \
+                            f"Unrelated field changed in {msg_type}"


### PR DESCRIPTION
Hello,

Thanks for this awesome project. I needed it for a pentest and could build a bit on top of it to make it easier to fuzz protobuf requests.

I added:

- A `MessageEditorTab` so that we can directly view the decoded protobuf in the Burp tool (Repeater, Proxy, Intruder...) AND automatically encode it back if we changed anything.
- Scanner insertion points: now if you right click on a `application/grpc-web-text` HTTP request / host -> Scan -> Active Scan, Burp will manage to recognize the format, decode it, insert payloads in any field, and encode it back.

Example of a test made by Burp with this extension:

```
1: {
  9: 0
  10: 0
  19: {"test"}
  25: {
    "#{\"\".getClass().forName(\"java.net.URL\").getConstructors()[2].newInstance(\"http:/"
  "/xxxx.oastify.com.\").hashCode()}"
  }
}
10: {2: 20}

```

Screenshot of the tab (available for both Request and Response):

![image](https://github.com/user-attachments/assets/8570de16-b3e5-4489-b908-8c5bcd8612c2)

I didn't respect your file naming convention because Python requires `_` instead of `-` if we want to reference code other unit files (as done for the unit tests)
